### PR TITLE
Add parameter to allow custom BitStrength for keys

### DIFF
--- a/lib/rsa_encrypt.dart
+++ b/lib/rsa_encrypt.dart
@@ -14,9 +14,33 @@ class RsaKeyHelper {
   ///
   /// Returns a [AsymmetricKeyPair] based on the [RSAKeyGenerator] with custom parameters,
   /// including a [SecureRandom]
+  ///
+  /// The parameter [secureRandomAndBitStrength] is an array of length 2 that
+  /// uses a [SecureRandom] as first value and an [int] as second value for the BitStrength
+  ///
+  /// Recommended BitStrength [1024, 2048 or 4096] - default BitStrength [2048]
+  static AsymmetricKeyPair<PublicKey, PrivateKey> getRsaKeyPair(
+      List<dynamic> secureRandomAndBitStrength) {
+    var rsapars = new RSAKeyGeneratorParameters(
+        BigInt.from(65537), secureRandomAndBitStrength.last, 5);
+    var params =
+        new ParametersWithRandom(rsapars, secureRandomAndBitStrength.first);
+    var keyGenerator = new RSAKeyGenerator();
+    keyGenerator.init(params);
+    return keyGenerator.generateKeyPair();
+  }
+
+  /// Generate a [PublicKey] and [PrivateKey] pair
+  ///
+  /// Returns a [AsymmetricKeyPair] based on the [RSAKeyGenerator] with custom parameters,
+  /// including a [SecureRandom]
+  ///
+  /// Accepts a custom [int] as BitStrength. Recommended BitStrength [1024, 2048 or 4096]
+  /// - default BitStrength [2048]
   Future<AsymmetricKeyPair<PublicKey, PrivateKey>> computeRSAKeyPair(
-      SecureRandom secureRandom) async {
-    return await compute(getRsaKeyPair, secureRandom);
+      SecureRandom secureRandom,
+      {int bitStrength = 2048}) async {
+    return await compute(getRsaKeyPair, [secureRandom, bitStrength]);
   }
 
   /// Generates a [SecureRandom] to use in computing RSA key pair
@@ -246,18 +270,4 @@ String decrypt(String ciphertext, RSAPrivateKey privateKey) {
   var decrypted = cipher.process(new Uint8List.fromList(ciphertext.codeUnits));
 
   return new String.fromCharCodes(decrypted);
-}
-
-/// Generate a [PublicKey] and [PrivateKey] pair
-///
-/// Returns a [AsymmetricKeyPair] based on the [RSAKeyGenerator] with custom parameters,
-/// including a [SecureRandom]
-AsymmetricKeyPair<PublicKey, PrivateKey> getRsaKeyPair(
-    SecureRandom secureRandom) {
-  /// Set BitStrength to [1024, 2048 or 4096]
-  var rsapars = new RSAKeyGeneratorParameters(BigInt.from(65537), 2048, 5);
-  var params = new ParametersWithRandom(rsapars, secureRandom);
-  var keyGenerator = new RSAKeyGenerator();
-  keyGenerator.init(params);
-  return keyGenerator.generateKeyPair();
 }


### PR DESCRIPTION
It would be great to assign a custom bit length to the RSA key generation. [Some time](https://stackoverflow.com/a/63531015/10874817) in the last couple of months, the `compute` method for isolates got extended which allows the method to execute static functions. This change gives us the ability to provide a custom bit length.

I've used an array as a parameter for the `getRsaKeyPair` function to mock a tuple. If you think another data type would be more fitting feel free to adapt the proposal.